### PR TITLE
Fix issue with text on latest version of web.whatsapp

### DIFF
--- a/css/WebWhatsapp.css
+++ b/css/WebWhatsapp.css
@@ -115,7 +115,8 @@ body {
     background-color: #2d2d2d !important;
 }
 .document-meta,
-.message-text {
+.message-text,
+.message-in .selectable-text {
     color: #d3d3d3 !important;
 }
 .message-datetime {


### PR DESCRIPTION
This fixes an issue with the latest version of web.whatsapp wherein the `message-text` class isn't applied, but instead it's `.selectable-text` (or `copyable-text`) underneath a `message-in` element.